### PR TITLE
Add modular dotfiles and installer

### DIFF
--- a/ARCH-POSTINSTALL-LOG.md
+++ b/ARCH-POSTINSTALL-LOG.md
@@ -1,0 +1,1 @@
+# Arch Post-Install Log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# dots
+# Dotfiles
+
+These dotfiles provide a modular configuration for a Hyprland-based setup on Arch Linux. Clone this repository into `~/dotfiles` and run `install.sh` to set everything up.
+
+## Structure
+- `hypr/` - Hyprland window manager configuration
+- `waybar/` - Status bar configurations (top and bottom)
+- `swww/` - Wallpaper daemon configuration
+- `dunst/` - Notification daemon
+- `rofi/` - Rofi launcher configuration
+- `kitty/` - Kitty terminal configuration
+- `fish/` - Fish shell configuration
+
+Each subdirectory contains a small README explaining the module. All configuration files are intended to be symlinked into `~/.config`. For example:
+
+```bash
+ln -s ~/dotfiles/kitty ~/.config/kitty
+```
+
+See `install.sh` for an automated installer that also handles packages and system services.
+
+## TODO
+- Expand configs as the system grows
+- Add more themes and scripts

--- a/dunst/README.md
+++ b/dunst/README.md
@@ -1,0 +1,3 @@
+# Dunst Configuration
+
+Dunst is a lightweight notification daemon. The provided `dunstrc` is a basic configuration with a dark theme.

--- a/dunst/dunstrc
+++ b/dunst/dunstrc
@@ -1,0 +1,7 @@
+[global]
+font = JetBrains Mono 10
+
+[urgency_low]
+timeout = 3
+background = "#222222"
+foreground = "#FFFFFF"

--- a/fish/README.md
+++ b/fish/README.md
@@ -1,0 +1,3 @@
+# Fish Shell
+
+Basic configuration for the Fish shell. The `config.fish` file adds a few helpful aliases and enables color prompt.

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,0 +1,3 @@
+set -g -x EDITOR nvim
+alias ls='ls --color=auto'
+fish_vi_key_bindings

--- a/hypr/README.md
+++ b/hypr/README.md
@@ -1,0 +1,5 @@
+# Hyprland Configuration
+
+This folder contains modular configuration files for the Hyprland compositor. The main entry point is `hyprland.conf` which includes files from `conf.d/`.
+
+The configuration sets the keyboard layout to Swedish and enables NumLock by default. Adjust or extend the files in `conf.d/` to customize your setup.

--- a/hypr/conf.d/general.conf
+++ b/hypr/conf.d/general.conf
@@ -1,0 +1,7 @@
+$mod = SUPER
+
+monitor=,preferred,auto,1
+
+exec-once = waybar
+bind = $mod, RETURN, exec, kitty
+bind = $mod, Q, killactive,

--- a/hypr/conf.d/input.conf
+++ b/hypr/conf.d/input.conf
@@ -1,0 +1,4 @@
+input {
+    kb_layout = se
+    numlock_by_default = yes
+}

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -1,0 +1,2 @@
+source = ~/.config/hypr/conf.d/input.conf
+source = ~/.config/hypr/conf.d/general.conf

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+REPO_DIR="$HOME/dotfiles"
+LOGFILE="$REPO_DIR/ARCH-POSTINSTALL-LOG.md"
+
+log() {
+    echo -e "$(date '+%F %T') | $*" | tee -a "$LOGFILE"
+}
+
+require_repo() {
+    if [[ "$PWD" != "$REPO_DIR" ]]; then
+        log "Please run this script from $REPO_DIR"
+        exit 1
+    fi
+}
+
+check_yay() {
+    if ! command -v yay &>/dev/null; then
+        read -rp "yay-bin is not installed. Install it now? [y/N] " ans
+        if [[ $ans =~ ^[Yy]$ ]]; then
+            sudo pacman -S --needed yay-bin || log "Failed to install yay-bin"
+        else
+            log "yay-bin missing; some packages may not install"
+        fi
+    fi
+}
+
+install_packages() {
+    read -rp "Install packages? [y/N] " ans
+    [[ $ans =~ ^[Yy]$ ]] || return
+
+    pkgs=(
+        hyprland waybar swww dunst rofi-wayland kitty fish brave-bin ollama claude-code cursor-bin
+        ttf-jetbrains-mono ttf-fira-code-nerd
+        mesa vulkan-radeon libva-mesa-driver
+    )
+
+    for pkg in "${pkgs[@]}"; do
+        if yay -Qi "$pkg" &>/dev/null; then
+            log "$pkg already installed"
+            continue
+        fi
+        log "Installing $pkg"
+        if yay -S --noconfirm "$pkg" >>"$LOGFILE" 2>&1; then
+            log "$pkg installed"
+        else
+            log "Failed to install $pkg"
+        fi
+    done
+}
+
+link_config() {
+    local dir=$1
+    local src="$REPO_DIR/$dir"
+    local dest="$HOME/.config/$dir"
+
+    if [[ -e $dest && ! -L $dest ]]; then
+        read -rp "$dest exists. Back up and replace with symlink? [y/N] " ans
+        if [[ $ans =~ ^[Yy]$ ]]; then
+            mv "$dest" "${dest}.bak" && log "Backed up $dest"
+        else
+            log "Skipped linking $dest"
+            return
+        fi
+    fi
+    mkdir -p "$(dirname "$dest")"
+    ln -sfn "$src" "$dest"
+    log "Linked $src -> $dest"
+}
+
+link_configs() {
+    read -rp "Symlink configuration directories? [y/N] " ans
+    [[ $ans =~ ^[Yy]$ ]] || return
+    for d in hypr waybar swww dunst rofi kitty fish; do
+        link_config "$d"
+    done
+}
+
+enable_services() {
+    read -rp "Enable common services (pipewire bluetooth)? [y/N] " ans
+    [[ $ans =~ ^[Yy]$ ]] || return
+    services=(pipewire bluetooth)
+    for svc in "${services[@]}"; do
+        if systemctl --user &>/dev/null; then
+            target="--user $svc.service"
+        else
+            target="$svc.service"
+        fi
+        if systemctl is-enabled $target &>/dev/null; then
+            log "$svc already enabled"
+        else
+            if sudo systemctl enable --now $svc.service >>"$LOGFILE" 2>&1; then
+                log "Enabled $svc"
+            else
+                log "Failed to enable $svc"
+            fi
+        fi
+    done
+}
+
+set_fish_default() {
+    if ! grep -q "/fish" <<<"$SHELL"; then
+        read -rp "Set fish as default shell? [y/N] " ans
+        if [[ $ans =~ ^[Yy]$ ]]; then
+            chsh -s /usr/bin/fish && log "Default shell changed to fish" || log "Failed to change shell"
+            log "A reboot is recommended to apply the shell change."
+        fi
+    fi
+}
+
+main() {
+    require_repo
+    touch "$LOGFILE"
+    log "Starting install script"
+    check_yay
+    install_packages
+    link_configs
+    enable_services
+    set_fish_default
+    log "Install script finished"
+}
+
+main "$@"

--- a/kitty/README.md
+++ b/kitty/README.md
@@ -1,0 +1,3 @@
+# Kitty Terminal
+
+This folder contains a small starter configuration for the Kitty terminal emulator.

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -1,0 +1,3 @@
+font_family JetBrainsMono Nerd Font
+font_size 12
+background_opacity 0.95

--- a/rofi/README.md
+++ b/rofi/README.md
@@ -1,0 +1,3 @@
+# Rofi Configuration
+
+The configuration here uses the `rofi-wayland` build. It provides a simple dark theme and fuzzy matching for launching applications.

--- a/rofi/config.rasi
+++ b/rofi/config.rasi
@@ -1,0 +1,7 @@
+configuration {
+    modi: "drun,run";
+    font: "JetBrains Mono 12";
+    display-drun: "Applications";
+    location: 0;
+    theme: "gruvbox-dark";
+}

--- a/swww/README.md
+++ b/swww/README.md
@@ -1,0 +1,3 @@
+# swww Configuration
+
+`swww` provides simple wallpaper management for Wayland. The `start.sh` script sets a random image from the `wallpapers` directory.

--- a/swww/start.sh
+++ b/swww/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+WALLPAPER_DIR="$HOME/Pictures/wallpapers"
+wallpaper=$(find "$WALLPAPER_DIR" -type f | shuf -n 1)
+swww img "$wallpaper" --transition-type any

--- a/waybar/README.md
+++ b/waybar/README.md
@@ -1,0 +1,3 @@
+# Waybar Configuration
+
+This directory contains two separate Waybar configurations: `top/` and `bottom/`. Each folder has its own `config` and `style.css` so you can mix and match bars.

--- a/waybar/bottom/config
+++ b/waybar/bottom/config
@@ -1,0 +1,5 @@
+{
+  "layer": "bottom",
+  "modules-left": ["tray"],
+  "modules-right": ["battery"]
+}

--- a/waybar/bottom/style.css
+++ b/waybar/bottom/style.css
@@ -1,0 +1,4 @@
+* {
+  font-family: "JetBrainsMono Nerd Font", monospace;
+  font-size: 13px;
+}

--- a/waybar/top/config
+++ b/waybar/top/config
@@ -1,0 +1,6 @@
+{
+  "layer": "top",
+  "modules-left": ["hyprland/workspaces"],
+  "modules-center": ["clock"],
+  "modules-right": ["pulseaudio", "network"]
+}

--- a/waybar/top/style.css
+++ b/waybar/top/style.css
@@ -1,0 +1,4 @@
+* {
+  font-family: "JetBrainsMono Nerd Font", monospace;
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary
- add starter README with repo overview
- create modular configs for hyprland, waybar, swww, dunst, rofi, kitty, and fish
- add a stub post-install log
- implement install.sh interactive script

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_685f56654fc883219cfe4896ee1128cd